### PR TITLE
Change way the releases works

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ This repo is based on https://redmine.ms.mff.cuni.cz/projects/lindat-common thes
 - Install NodeJS environment (unless you already have one)
         
         curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.25.4/install.sh | bash
+        nvm install stable
+        nvm use stable
 
 - Install build tools Bower and Gulp
 
@@ -72,15 +74,11 @@ This repo is based on https://redmine.ms.mff.cuni.cz/projects/lindat-common thes
 
         gulp serve:angular
         
-- To build a new distribution
-
-        gulp build && gulp tag
-
 Making new release
 ------------------
 
-| Task             | Version                                |
-|------------------|----------------------------------------|
-| gulp tag         | v0.0.1 -> v0.0.2 + commit + tag + push |
-| gulp tag --minor | v0.0.1 -> v0.1.0 + commit + tag + push |
-| gulp tag --major | v0.0.1 -> v1.0.1 + commit + tag + push |
+| Task                 | Version                                |
+|----------------------|----------------------------------------|
+| gulp release         | v0.0.1 -> v0.0.2 + commit + tag + push |
+| gulp release --minor | v0.0.1 -> v0.1.0 + commit + tag + push |
+| gulp release --major | v0.0.1 -> v1.0.1 + commit + tag + push |

--- a/ci/push_release.sh
+++ b/ci/push_release.sh
@@ -40,7 +40,17 @@ git config user.email "$git_email"
 
 touch .
 
+git remote add origin "https://$GH_TOKEN@github.com/ufal/lindat-common.git"
+# Fetch remote refs to a specific branch, equivalent to a pull without checkout
+git fetch --update-head-ok origin releases:master
+# Make the current working tree the branch HEAD without checking out files
+git symbolic-ref HEAD refs/heads/master
+# Make sure the stage is clean
+git reset
+
+# Track releases branch
+git branch --set-upstream-to=origin/releases master
+
 git add -A .
 git commit -m "Release build based on ${rev}"
-git push --force -q "https://$GH_TOKEN@github.com/ufal/lindat-common.git" master:releases > /dev/null 2>&1
-
+git push -q origin master:releases > /dev/null 2>&1

--- a/gulp/release.js
+++ b/gulp/release.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var gulp = require('gulp');
+var $ = require('gulp-load-plugins')();
+
+var fs = require('fs');
+var argv = require('yargs').argv;
+
+var files = ['./package.json', './bower.json'];
+
+function getPackageJson() {
+  return JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+}
+
+module.exports = function(options) {
+
+  function versioning() {
+    if (argv.minor || argv.feature) {
+      return 'minor';
+    }
+    if (argv.major) {
+      return 'major';
+    }
+    return 'patch';
+  };
+
+  gulp.task('bump', function() {
+    return gulp.src(files)
+      .pipe($.bump({type: versioning()}))
+      .pipe(gulp.dest('.'));
+  });
+
+  gulp.task('add:dist', ['build'], function() {
+    return gulp.src( options.dist + '/**')
+      .pipe($.git.add({args: '-f'}));
+  });
+
+  gulp.task('add:version', ['bump'], function() {
+    return gulp.src(files)
+      .pipe($.git.add());
+  });
+
+  gulp.task('add', ['add:dist', 'add:version']);
+
+  gulp.task('release', ['add'], function() {
+    var pkg = getPackageJson();
+    return gulp.src('./package.json')
+      .pipe($.git.commit('Releasing version ' + pkg.version))     
+      .pipe($.tagVersion())
+      .pipe($.git.push('origin', 'master', {args: '--tags'}));
+  });
+
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,8 +4,6 @@ var gulp = require('gulp');
 var gutil = require('gulp-util');
 var wrench = require('wrench');
 
-require('gulp-release-tasks')(gulp);
-
 var options = {
   src: 'src',
   dist: 'dist',

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
     "gulp-angular-filesort": "^1.1.1",
     "gulp-angular-templatecache": "^1.7.0",
     "gulp-autoprefixer": "~2.3.1",
+    "gulp-bump": "^0.3.1",
     "gulp-concat": "^2.6.0",
     "gulp-csso": "~1.0.0",
     "gulp-data": "^1.2.0",
     "gulp-filter": "~2.0.2",
+    "gulp-git": "^1.2.4",
     "gulp-image-optimization": "^0.1.3",
     "gulp-inject": "~1.3.1",
     "gulp-jshint": "^1.11.2",
@@ -28,11 +30,11 @@
     "gulp-minify-html": "~1.0.3",
     "gulp-ng-annotate": "^1.0.0",
     "gulp-preprocess": "^1.2.0",
-    "gulp-release-tasks": "0.0.3",
     "gulp-rename": "~1.2.2",
     "gulp-replace": "~0.5.3",
     "gulp-sourcemaps": "~1.5.2",
     "gulp-swig": "^0.7.4",
+    "gulp-tag-version": "^1.3.0",
     "gulp-tap": "^0.1.3",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "~3.0.6",
@@ -44,7 +46,8 @@
     "require-dir": "~0.3.0",
     "run-sequence": "^1.1.2",
     "wiredep": "^3.0.0-beta",
-    "wrench": "~1.5.8"
+    "wrench": "~1.5.8",
+    "yargs": "^3.17.1"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Releasing new version now consits of several steps:

- Run `gulp release` (the rest of steps will happen automatically)
This will build > tag > commit > push a new tag for a release

- Travis will then make new Github release

- The change will also propagates to Github pages and separate releases branch